### PR TITLE
header's reordering

### DIFF
--- a/imhtml.cpp
+++ b/imhtml.cpp
@@ -1,14 +1,18 @@
-#include "imhtml.hpp"
 
 #include <chrono>
 #include <fstream>
 #include <iostream>
 #include <string>
 
+#define IMGUI_DEFINE_MATH_OPERATORS
+
 #include "imgui.h"
 #include "imgui_internal.h"
 #include "litehtml.h"
 #include "litehtml/types.h"
+
+#include "imhtml.hpp"
+
 
 namespace ImHTML {
 

--- a/imhtml.hpp
+++ b/imhtml.hpp
@@ -6,7 +6,6 @@
 #include "litehtml.h"
 #include "litehtml/html_tag.h"
 
-#define IMGUI_DEFINE_MATH_OPERATORS
 #include "imgui.h"
 #include "imgui_internal.h"
 


### PR DESCRIPTION
I fixed the order of includes, so to ensure IMGUI flags are not bleeling through in final users's project.
The idea is that the specific choice of exposing the math utils is guarded to avoid wider compatibility issues, and should stay within the imhtml cpp file.

I am using this patch in my project to avoid some compile issues, and I was able to build & run the demo app in this repo.