### PR TITLE
Removed explicit dependency from litehtml in header

### DIFF
--- a/imhtml.cpp
+++ b/imhtml.cpp
@@ -16,6 +16,24 @@
 
 namespace ImHTML {
 
+/**
+ * Custom element
+ */
+class CustomElement : public litehtml::html_tag {
+ private:
+  std::string tag = "";
+  std::map<std::string, std::string> attributes = {};
+
+ public:
+  CustomElement(const std::shared_ptr<litehtml::document> &doc, const std::string &tag,
+                std::map<std::string, std::string> attributes)
+      : litehtml::html_tag(doc), tag(tag), attributes(attributes) {}
+
+  void draw_background(litehtml::uint_ptr hdc, int x, int y, const litehtml::position *clip,
+                       const std::shared_ptr<litehtml::render_item> &ri) override;
+};
+
+
 std::string DefaultFileLoader(const char *url, const char *baseurl) {
   if (url == nullptr || strlen(url) == 0) {
     return "";

--- a/imhtml.hpp
+++ b/imhtml.hpp
@@ -2,9 +2,7 @@
 
 #include <functional>
 #include <string>
-
-#include "litehtml.h"
-#include "litehtml/html_tag.h"
+#include <map>
 
 #include "imgui.h"
 #include "imgui_internal.h"
@@ -51,23 +49,6 @@ struct Config {
  * @param attributes The attributes of the element
  */
 typedef std::function<void(ImRect bounds, std::map<std::string, std::string> attributes)> CustomElementDrawFunction;
-
-/**
- * Custom element
- */
-class CustomElement : public litehtml::html_tag {
- private:
-  std::string tag = "";
-  std::map<std::string, std::string> attributes = {};
-
- public:
-  CustomElement(const std::shared_ptr<litehtml::document> &doc, const std::string &tag,
-                std::map<std::string, std::string> attributes)
-      : litehtml::html_tag(doc), tag(tag), attributes(attributes) {}
-
-  void draw_background(litehtml::uint_ptr hdc, int x, int y, const litehtml::position *clip,
-                       const std::shared_ptr<litehtml::render_item> &ri) override;
-};
 
 /**
  * Default file loader for loading CSS files


### PR DESCRIPTION
Including litehtml requires explicit linking with the same library for downstream projects, even if they don't really need visibility or access to the rendering engine itself, and that is nowhere used in the public interface since all registration calls are wrapped already.  
This was just solved by moving the CustomElement class specific to the cpp file.

Still, this PR includes https://github.com/BigJk/ImHTML/pull/1 as it was not easy to decouple these changes from it, so you might want to consider that first.